### PR TITLE
Bump golangci-lint to v2.8.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,9 +12,6 @@ include:
 
 variables:
   GITLAB_ADVANCED_SAST_ENABLED: 'true'
-  # Keep in sync with go.mod "go" directive.
-  GO_VERSION: '1.25.6'
-  GOLANGCI_LINT_VERSION: 'v1.64.0'
 
 container_scanning:
   variables:
@@ -22,16 +19,15 @@ container_scanning:
 
 lint:
   stage: test
-  image: golang:${GO_VERSION}-trixie
+  image: golangci/golangci-lint:v2.8.0
   script:
-    - go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
     - golangci-lint run -v -E gofmt -E goconst -E gocritic -E gocognit -E gocyclo
   except:
     - schedules
 
 end-to-end:
   stage: test
-  image: golang:${GO_VERSION}-trixie
+  image: golang:1.25.6-trixie
   variables:
     ENABLE_E2E_TESTS: 1
     E2E_START_APP: 1
@@ -47,15 +43,13 @@ end-to-end:
 
 container-image:
   stage: build
-  needs: []
   image: docker:latest
   services:
-    - name: docker:dind
-      command: ['--mtu=1400']
+    - docker:dind
   before_script:
     - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
   script:
-    - docker build --pull -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA" .
+    - docker buildx build --pull -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA" --platform linux/arm64 .
     - docker tag "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA" $CI_REGISTRY_IMAGE
     - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA"
     - docker push $CI_REGISTRY_IMAGE
@@ -63,7 +57,6 @@ container-image:
     - master
   except:
     - schedules
-  tags: [saas-linux-large-arm64]
 
 .setup-ssh: &setup-ssh
   - eval $(ssh-agent -s) > /dev/null
@@ -110,7 +103,7 @@ production:
 
 prod-end-to-end:
   stage: verify
-  image: golang:${GO_VERSION}-trixie
+  image: golang:1.25.6-trixie
   variables:
     ENABLE_E2E_TESTS: 1
     E2E_DISCORD_CHANNEL_ID: $E2E_PROD_DISCORD_CHANNEL_ID


### PR DESCRIPTION
## Summary
- update golangci/golangci-lint image to v1.64.8

## Testing
- not run