### PR TITLE
Bump golangci-lint to v2.8.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ lint:
   image: golang:${GO_VERSION}-trixie
   script:
     - go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
-    - golangci-lint run -v -E gofmt -E goconst -E gocritic -E gocognit -E gocyclo
+    - golangci-lint run -v -E goconst -E gocritic -E gocognit -E gocyclo
   except:
     - schedules
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   GITLAB_ADVANCED_SAST_ENABLED: 'true'
   # Keep in sync with go.mod "go" directive.
   GO_VERSION: '1.25.6'
-  GOLANGCI_LINT_VERSION: 'v1.64.0'
+  GOLANGCI_LINT_VERSION: 'v2.8.0'
 
 container_scanning:
   variables:


### PR DESCRIPTION
## Summary
- update golangci-lint to v2.8.0 in CI

## Testing
- not run