### PR TITLE
Fix golangci-lint v2 install path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ lint:
   stage: test
   image: golang:${GO_VERSION}-trixie
   script:
-    - go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+    - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
     - golangci-lint run -v -E goconst -E gocritic -E gocognit -E gocyclo
   except:
     - schedules


### PR DESCRIPTION
## Summary
- use the /v2 module path for golangci-lint install in CI

## Testing
- not run